### PR TITLE
Add filesystem permissions

### DIFF
--- a/io.github.strikerx3.ymir.yaml
+++ b/io.github.strikerx3.ymir.yaml
@@ -12,6 +12,9 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
   - --device=all
+  - --filesystem=host:ro
+  - --filesystem=home
+  #- --filesystem=xdg-run/app/com.discordapp.Discord:ro  # for Discord rich presence
 modules:
   - name: cereal
     buildsystem: cmake


### PR DESCRIPTION
Adds read-only permission to the entire host filesystem to load discs from anywhere, and read-write permissions to the home directory so users can use the "Installed" mode without errors.