### PR TITLE
Grant read-only permissions to external media

### DIFF
--- a/io.github.strikerx3.ymir.yaml
+++ b/io.github.strikerx3.ymir.yaml
@@ -12,6 +12,10 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
   - --device=all
+  # Grant access to external media (for example, Steam Deck)
+  - --filesystem=/media:ro
+  - --filesystem=/mnt:ro
+  - --filesystem=/run/media:ro
 modules:
   - name: cereal
     buildsystem: cmake


### PR DESCRIPTION
This is for cases where users store game disc images in external media, such as when using a Steam Deck.